### PR TITLE
Besseres Management verschiedener Image versionen 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-ARG base_image=openjdk:8-jdk
+ARG BASE_IMAGE=openjdk:8-jdk
 
 FROM $base_image
-ARG gradle_version=4.10.3
+ARG GRADLE_VERSION=4.10.3
 
 RUN apt-get update && apt-get install -y wget build-essential apt-transport-https ca-certificates curl gnupg2 software-properties-common tar git openssl gzip unzip
 
@@ -48,7 +48,7 @@ ENV GRADLE_HOME /opt/gradle
 RUN wget --output-document=gradle.zip  https://services.gradle.org/distributions/gradle-${gradle_version}-bin.zip && \
     unzip gradle.zip && \
     rm gradle.zip && \
-    mv "gradle-${gradle_version}" "${GRADLE_HOME}/" && \
+    mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" && \
     ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
 
 # Neustes npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x > install.sh && chmod +x inst
 
 ## PhantomJS
 RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list.d/phantomjs.list && \
-apt-get update && apt-get install -y phantomjs
+    apt-get update && apt-get install -y phantomjs
 
 ## Gradle
 ENV GRADLE_HOME /opt/gradle

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM openjdk:8-jdk
+ARG base_image=openjdk:8-jdk
+
+FROM $base_image
+ARG gradle_version=4.10.3
 
 RUN apt-get update && apt-get install -y wget build-essential apt-transport-https ca-certificates curl gnupg2 software-properties-common tar git openssl gzip unzip
 
@@ -24,7 +27,7 @@ RUN curl -L https://github.com/docker/compose/releases/download/1.23.2/docker-co
 
 # Kompose
 RUN curl -L https://github.com/kubernetes/kompose/releases/download/v1.17.0/kompose-linux-amd64 -o /usr/local/bin/kompose && \
-    chmod +x /usr/local/bin/kompose && \ 
+    chmod +x /usr/local/bin/kompose && \
     kompose -v
 
 ## Rancher Compose
@@ -38,15 +41,14 @@ RUN curl -sL https://deb.nodesource.com/setup_10.x > install.sh && chmod +x inst
 
 ## PhantomJS
 RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' >> /etc/apt/sources.list.d/phantomjs.list && \
-    apt-get update && apt-get install -y phantomjs
+apt-get update && apt-get install -y phantomjs
 
 ## Gradle
 ENV GRADLE_HOME /opt/gradle
-ENV GRADLE_VERSION 4.10.2
-RUN wget --output-document=gradle.zip  https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip && \
+RUN wget --output-document=gradle.zip  https://services.gradle.org/distributions/gradle-${gradle_version}-bin.zip && \
     unzip gradle.zip && \
     rm gradle.zip && \
-    mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" && \
+    mv "gradle-${gradle_version}" "${GRADLE_HOME}/" && \
     ln --symbolic "${GRADLE_HOME}/bin/gradle" /usr/bin/gradle
 
 # Neustes npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=openjdk:8-jdk
 
-FROM $base_image
+FROM $BASE_IMAGE
 ARG GRADLE_VERSION=4.10.3
 
 RUN apt-get update && apt-get install -y wget build-essential apt-transport-https ca-certificates curl gnupg2 software-properties-common tar git openssl gzip unzip
@@ -45,7 +45,7 @@ apt-get update && apt-get install -y phantomjs
 
 ## Gradle
 ENV GRADLE_HOME /opt/gradle
-RUN wget --output-document=gradle.zip  https://services.gradle.org/distributions/gradle-${gradle_version}-bin.zip && \
+RUN wget --output-document=gradle.zip  https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip && \
     unzip gradle.zip && \
     rm gradle.zip && \
     mv "gradle-${GRADLE_VERSION}" "${GRADLE_HOME}/" && \

--- a/hooks/build
+++ b/hooks/build
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Mit diesem Script wird der Docker Hub build Prozess gehooked, 
+# damit mehrere Tags auf einmal gebaut werden können.
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 

--- a/hooks/build
+++ b/hooks/build
@@ -7,7 +7,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $DIR/versions.sh
 
 while read -r line; do
-    if [ ${#line} -ne 0 ]; then  # Ignore the empty lines
+    if [ ${#line} -ne 0 ]; then  # Ignoriere leerzeilen
         eval "$line source $DIR/build.sh"
     fi
 done <<< "$VARS"

--- a/hooks/build
+++ b/hooks/build
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source $DIR/versions.sh
+
+while read -r line; do
+    if [ ${#line} -ne 0 ]; then  # Ignore the empty lines
+        eval "$line source $DIR/build.sh"
+    fi
+done <<< "$VARS"

--- a/hooks/build.sh
+++ b/hooks/build.sh
@@ -24,8 +24,8 @@ echo "Benutze Base Image ${BASE_IMAGE}"
 
 docker build . \
     -t "$TAG" \
-    --build-arg base_image=$BASE_IMAGE \
-    --build-arg gradle_version=$FULL_GRADLE_VERSION
+    --build-arg BASE_IMAGE=$BASE_IMAGE \
+    --build-arg GRADLE_VERSION=$FULL_GRADLE_VERSION
 
 IMAGE_ID=$(docker images $TAG --format "{{.ID}}")
 

--- a/hooks/build.sh
+++ b/hooks/build.sh
@@ -2,7 +2,6 @@
 
 TAG="emundo/docker-compose-openjdk-node-gradle:${BASE_IMAGE_TAG}"
 
-# Hole alle möglichen gradle release versionen
 echo 'Lade alle verfügbraen Gradle Versionen'
 PAGE_URL='https://services.gradle.org/versions/all'
 PAGE_DATA="$(curl -fsSL "$pageUrl")"
@@ -13,7 +12,7 @@ allGradleVersions=( $(
 			| grep -oP '(?<="version" : ")[\d.]+(?=",)'
 ))
 
-# Lade höchste Minor Version die passt
+# Suche die höchste Minor Version die passt
 FULL_GRADLE_VERSION="$(
 		echo "${allGradleVersions[@]}" | xargs -n1 \
 			| grep -E "^${GRADLE_VERSION}(.*)$" \
@@ -21,8 +20,7 @@ FULL_GRADLE_VERSION="$(
 			| tail -1
 	    )" || true
 echo "Benutze Gradle ${FULL_GRADLE_VERSION}"
-echo "Benutzer Base Image ${BASE_IMAGE}"
-set -x
+echo "Benutze Base Image ${BASE_IMAGE}"
 
 docker build . \
     --no-cache \

--- a/hooks/build.sh
+++ b/hooks/build.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-TAG="emundo/docker-compose-openjdk-node-gradle:${BASE_IMAGE_TAG}"
+TAG="emundo/docker-compose-openjdk-node-gradle:${IMAGE_TAG}"
 
 echo 'Lade alle verfügbraen Gradle Versionen'
 PAGE_URL='https://services.gradle.org/versions/all'
-PAGE_DATA="$(curl -fsSL "$pageUrl")"
+PAGE_DATA="$(curl -fsSL "$PAGE_URL")"
 # Parse alle Release Versionen aus json String
 allGradleVersions=()
 allGradleVersions=( $(
@@ -23,10 +23,16 @@ echo "Benutze Gradle ${FULL_GRADLE_VERSION}"
 echo "Benutze Base Image ${BASE_IMAGE}"
 
 docker build . \
-    --no-cache \
     -t "$TAG" \
     --build-arg base_image=$BASE_IMAGE \
     --build-arg gradle_version=$FULL_GRADLE_VERSION
 
-image_id=$(docker images $TAG --format "{{.ID}}")
+IMAGE_ID=$(docker images $TAG --format "{{.ID}}")
+
+
+for tag in ${EXTRA_TAGS//;/$'\n'}
+do
+    echo $tag
+    docker tag $IMAGE_ID "emundo/docker-compose-openjdk-node-gradle:${tag}"
+done
 

--- a/hooks/build.sh
+++ b/hooks/build.sh
@@ -2,25 +2,25 @@
 
 TAG="emundo/docker-compose-openjdk-node-gradle:${BASE_IMAGE_TAG}"
 
-
 # Hole alle möglichen gradle release versionen
 echo 'Lade alle verfügbraen Gradle Versionen'
-pageUrl='https://services.gradle.org/versions/all'
-page="$(curl -fsSL "$pageUrl")"
+PAGE_URL='https://services.gradle.org/versions/all'
+PAGE_DATA="$(curl -fsSL "$pageUrl")"
 # Parse alle Release Versionen aus json String
 allGradleVersions=()
 allGradleVersions=( $(
-		echo "$page" \
+		echo "$PAGE_DATA" \
 			| grep -oP '(?<="version" : ")[\d.]+(?=",)'
 ))
+
 # Lade höchste Minor Version die passt
-gradle_full_version="$(
+FULL_GRADLE_VERSION="$(
 		echo "${allGradleVersions[@]}" | xargs -n1 \
 			| grep -E "^${GRADLE_VERSION}(.*)$" \
             | sort -V \
 			| tail -1
 	    )" || true
-echo "Benutze Gradle ${gradle_full_version}"
+echo "Benutze Gradle ${FULL_GRADLE_VERSION}"
 echo "Benutzer Base Image ${BASE_IMAGE}"
 set -x
 
@@ -28,7 +28,7 @@ docker build . \
     --no-cache \
     -t "$TAG" \
     --build-arg base_image=$BASE_IMAGE \
-    --build-arg gradle_version=$gradle_full_version 
+    --build-arg gradle_version=$FULL_GRADLE_VERSION
 
 image_id=$(docker images $TAG --format "{{.ID}}")
 

--- a/hooks/build.sh
+++ b/hooks/build.sh
@@ -2,17 +2,17 @@
 
 TAG="emundo/docker-compose-openjdk-node-gradle:${IMAGE_TAG}"
 
-echo 'Lade alle verfügbraen Gradle Versionen'
+echo 'Lade alle verfügbaren Gradle-Versionen'
 PAGE_URL='https://services.gradle.org/versions/all'
 PAGE_DATA="$(curl -fsSL "$PAGE_URL")"
-# Parse alle Release Versionen aus json String
+# Parse alle Release-Versionen aus JSON-String
 allGradleVersions=()
 allGradleVersions=( $(
 		echo "$PAGE_DATA" \
 			| grep -oP '(?<="version" : ")[\d.]+(?=",)'
 ))
 
-# Suche die höchste Minor Version die passt
+# Suche die höchste Minor-Version die passt
 FULL_GRADLE_VERSION="$(
 		echo "${allGradleVersions[@]}" | xargs -n1 \
 			| grep -E "^${GRADLE_VERSION}(.*)$" \

--- a/hooks/build.sh
+++ b/hooks/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-TAG="robertschreib/docker-compose-openjdk-node-gradle:${BASE_IMAGE_TAG}"
+TAG="emundo/docker-compose-openjdk-node-gradle:${BASE_IMAGE_TAG}"
 
 
 # Hole alle möglichen gradle release versionen

--- a/hooks/build.sh
+++ b/hooks/build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+TAG="robertschreib/docker-compose-openjdk-node-gradle:${BASE_IMAGE_TAG}"
+
+
+# Hole alle möglichen gradle release versionen
+echo 'Lade alle verfügbraen Gradle Versionen'
+pageUrl='https://services.gradle.org/versions/all'
+page="$(curl -fsSL "$pageUrl")"
+# Parse alle Release Versionen aus json String
+allGradleVersions=()
+allGradleVersions=( $(
+		echo "$page" \
+			| grep -oP '(?<="version" : ")[\d.]+(?=",)'
+))
+# Lade höchste Minor Version die passt
+gradle_full_version="$(
+		echo "${allGradleVersions[@]}" | xargs -n1 \
+			| grep -E "^${GRADLE_VERSION}(.*)$" \
+            | sort -V \
+			| tail -1
+	    )" || true
+echo "Benutze Gradle ${gradle_full_version}"
+echo "Benutzer Base Image ${BASE_IMAGE}"
+set -x
+
+docker build . \
+    --no-cache \
+    -t "$TAG" \
+    --build-arg base_image=$BASE_IMAGE \
+    --build-arg gradle_version=$gradle_full_version 
+
+image_id=$(docker images $TAG --format "{{.ID}}")
+

--- a/hooks/push
+++ b/hooks/push
@@ -1,6 +1,6 @@
 #!/bin/bash
-# Mit diesem Script wird der Docker Hub build Prozess gehooked, 
-# damit mehrere Tags auf einmal gepushed werden können.
+# Mit diesem Script wird der Docker Hub push Prozess gehooked, 
+# damit mehrere Tags auf einmal in das Repository gepushed werden können.
 
 
 # Nur pushen wenn der Commit auf dem master ist

--- a/hooks/push
+++ b/hooks/push
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -ex
+
+# Don't push images if branch is not master
+echo "Current Branch: $SOURCE_BRANCH"
+if [ "${SOURCE_BRANCH}" != "master" ]; then
+    exit 0
+fi
+
+for tag in $(docker images robertschreib/docker-compose-openjdk-node-gradle --format "{{.Tag}}");
+do
+    docker push "${DOCKER_REPO}:${tag}"
+done

--- a/hooks/push
+++ b/hooks/push
@@ -8,7 +8,7 @@ if [ "${SOURCE_BRANCH}" != "master" ]; then
     exit 0
 fi
 
-for tag in $(docker images robertschreib/docker-compose-openjdk-node-gradle --format "{{.Tag}}");
+for tag in $(docker images emundo/docker-compose-openjdk-node-gradle --format "{{.Tag}}");
 do
     docker push "${DOCKER_REPO}:${tag}"
 done

--- a/hooks/push
+++ b/hooks/push
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 # Don't push images if branch is not master
 echo "Current Branch: $SOURCE_BRANCH"

--- a/hooks/push
+++ b/hooks/push
@@ -4,7 +4,7 @@
 
 
 # Nur pushen wenn der Commit auf dem master ist
-echo "Current Branch: $SOURCE_BRANCH"
+echo "Aktueller Branch: $SOURCE_BRANCH"
 if [ "${SOURCE_BRANCH}" != "master" ]; then
     exit 0
 fi

--- a/hooks/push
+++ b/hooks/push
@@ -1,8 +1,9 @@
 #!/bin/bash
+# Mit diesem Script wird der Docker Hub build Prozess gehooked, 
+# damit mehrere Tags auf einmal gepushed werden können.
 
-set -e
 
-# Don't push images if branch is not master
+# Nur pushen wenn der Commit auf dem master ist
 echo "Current Branch: $SOURCE_BRANCH"
 if [ "${SOURCE_BRANCH}" != "master" ]; then
     exit 0
@@ -10,5 +11,5 @@ fi
 
 for tag in $(docker images emundo/docker-compose-openjdk-node-gradle --format "{{.Tag}}");
 do
-    docker push "${DOCKER_REPO}:${tag}"
+    docker push "emundo/docker-compose-openjdk-node-gradle:${tag}"
 done

--- a/hooks/versions.sh
+++ b/hooks/versions.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+export VARS='
+BASE_IMAGE=openjdk:11-jdk GRADLE_VERSION=5.1 BASE_IMAGE_TAG="openjdk-11-gradle-5.1"
+BASE_IMAGE=openjdk:8-jdk GRADLE_VERSION=5.1 BASE_IMAGE_TAG="openjdk-8-gradle-5.1"
+BASE_IMAGE=openjdk:8-jdk GRADLE_VERSION=4.10 BASE_IMAGE_TAG="openjdk-8-gradle-4.10"
+BASE_IMAGE=openjdk:11-jdk GRADLE_VERSION=4.10 BASE_IMAGE_TAG="openjdk-11-gradle-4.10"
+'

--- a/hooks/versions.sh
+++ b/hooks/versions.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 export VARS='
-BASE_IMAGE=openjdk:11-jdk GRADLE_VERSION=5.1 BASE_IMAGE_TAG="openjdk-11-gradle-5.1"
-BASE_IMAGE=openjdk:8-jdk GRADLE_VERSION=5.1 BASE_IMAGE_TAG="openjdk-8-gradle-5.1"
-BASE_IMAGE=openjdk:8-jdk GRADLE_VERSION=4.10 BASE_IMAGE_TAG="openjdk-8-gradle-4.10"
-BASE_IMAGE=openjdk:11-jdk GRADLE_VERSION=4.10 BASE_IMAGE_TAG="openjdk-11-gradle-4.10"
+BASE_IMAGE=openjdk:11-jdk GRADLE_VERSION=5.1 IMAGE_TAG="openjdk-11-gradle-5.1"
+BASE_IMAGE=openjdk:8-jdk GRADLE_VERSION=5.1 IMAGE_TAG="openjdk-8-gradle-5.1"
+BASE_IMAGE=openjdk:8-jdk GRADLE_VERSION=4.10 IMAGE_TAG="openjdk-8-gradle-4.10" EXTRA_TAGS="openjdk-8;latest"
+BASE_IMAGE=openjdk:11-jdk GRADLE_VERSION=4.10 IMAGE_TAG="openjdk-11-gradle-4.10" EXTRA_TAGS="openjdk-11"
 '


### PR DESCRIPTION
Mit diesem Pull request ist es möglich Immages mit verschiedenen Gradle und Java Versionen automatisiert bauen und taggen zu lassen.

Auserdem soll auch noch in der Docker Cloud eingestellt werden, dass das Image bei update des Base Images neu gebaut wird.