### PR TITLE
Funktionierendes Docker Image benutzen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:rolling
+FROM ubuntu:disco
 
 RUN apt-get update && apt-get install -y wget apt-transport-https ca-certificates curl gnupg2 software-properties-common tar git openssl gzip unzip\
     && apt-get autoclean \


### PR DESCRIPTION
Mit ubuntu:rolling kommt die Fehlermeldung 
`E: The repository 'http://packages.cloud.google.com/apt cloud-sdk-eoan Release' does not have a Release file.`